### PR TITLE
refactor: Remove duplicate validation enum from register schema

### DIFF
--- a/src/schemas/register/register-schema.ts
+++ b/src/schemas/register/register-schema.ts
@@ -1,27 +1,19 @@
+import { ValidationMessages } from "@/constants/register/messages";
 import { z } from "zod";
-
-export enum RegisterValidationMessages {
-  EMAIL_REQUIRED = "Email is required",
-  EMAIL_INVALID = "Invalid email format",
-  PASSWORD_REQUIRED = "Password is required",
-  PASSWORD_MIN_LENGTH = "Password must be at least 6 characters",
-  PASSWORD_MAX_LENGTH = "Password must not exceed 50 characters",
-  PASSWORD_PATTERN = "Password must contain uppercase, lowercase, number and special character",
-}
 
 export const registerSchema = z.object({
   username: z
     .string()
-    .min(1, RegisterValidationMessages.EMAIL_REQUIRED)
-    .email(RegisterValidationMessages.EMAIL_INVALID),
+    .min(1, ValidationMessages.EMAIL_REQUIRED)
+    .email(ValidationMessages.EMAIL_INVALID),
   password: z
     .string()
-    .min(1, RegisterValidationMessages.PASSWORD_REQUIRED)
-    .min(6, RegisterValidationMessages.PASSWORD_MIN_LENGTH)
-    .max(50, RegisterValidationMessages.PASSWORD_MAX_LENGTH)
+    .min(1, ValidationMessages.PASSWORD_REQUIRED)
+    .min(6, ValidationMessages.PASSWORD_MIN_LENGTH)
+    .max(50, ValidationMessages.PASSWORD_MAX_LENGTH)
     .regex(
       /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{6,}$/,
-      RegisterValidationMessages.PASSWORD_PATTERN
+      ValidationMessages.PASSWORD_PATTERN
     ),
 });
 


### PR DESCRIPTION
# Summary

Remove duplicate validation messages enum from register schema and import it from the centralized messages constants file. This change reduces code duplication and maintains a single source of truth for validation messages across the application.
